### PR TITLE
Change ANTIALIAS to LANCZOS for compatibility with pillow >=10.0.0

### DIFF
--- a/gifterm
+++ b/gifterm
@@ -85,7 +85,7 @@ def playGifAscii(inGif, app, playtimes = 0):   # playtimes is number of times to
         signal.signal(signal.SIGWINCH, resizeHandler)
     except:     # windows
         pass
-    #frame.thumbnail((cols - 1, rows - 1), Image.ANTIALIAS)
+    #frame.thumbnail((cols - 1, rows - 1), Image.LANCZOS)
     #frame = frame.convert('RGB')
     app.mypalette = frame.getpalette()
     #lastframe = frame.convert('RGBA')
@@ -286,9 +286,9 @@ def renderFrame(outFile = None):
         statusBarSize = len(statusBarFormatted) - 1
     if app.smoothing:
         if app.displayInfo:
-            newframe.thumbnail((app.cols, app.rows - statusBarSize), Image.ANTIALIAS)
+            newframe.thumbnail((app.cols, app.rows - statusBarSize), Image.LANCZOS)
         else:
-            newframe.thumbnail((app.cols, app.rows), Image.ANTIALIAS)
+            newframe.thumbnail((app.cols, app.rows), Image.LANCZOS)
     else:
         if app.displayInfo:
             newframe.thumbnail((app.cols, app.rows - statusBarSize), Image.NEAREST)


### PR DESCRIPTION
Pillow was updated in v10 - https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants

This deprecates ANTIALIAS which caused gifterm to fail. This update fixes the failure moving forward.